### PR TITLE
Fix typo in quickstart-dotnet.md (Typo: "TableEntity" → "TableClient")

### DIFF
--- a/articles/cosmos-db/table/quickstart-dotnet.md
+++ b/articles/cosmos-db/table/quickstart-dotnet.md
@@ -121,7 +121,7 @@ Create an item in the collection using the `Product` class by calling [``TableCl
 
 ### Get an item
 
-You can retrieve a specific item from a table using the [``TableEntity.GetEntityAsync<T>``](/dotnet/api/azure.data.tables.tableclient.getentity) method. Provide the `partitionKey` and `rowKey` as parameters to identify the correct row to perform a quick *point read* of that item.
+You can retrieve a specific item from a table using the [``TableClient.GetEntityAsync<T>``](/dotnet/api/azure.data.tables.tableclient.getentity) method. Provide the `partitionKey` and `rowKey` as parameters to identify the correct row to perform a quick *point read* of that item.
 
 :::code language="csharp" source="~/azure-cosmos-tableapi-dotnet/001-quickstart/Program.cs" id="read_item" :::
 


### PR DESCRIPTION
In the "Get an item" section of the "Quickstart: Azure Cosmos DB for Table for .NET", TableEntity was mistakenly used instead of TableClient.